### PR TITLE
Fix division by zero in DiceRoller

### DIFF
--- a/backend/src/main/java/com/rolerolls/rolls/DiceRoller.java
+++ b/backend/src/main/java/com/rolerolls/rolls/DiceRoller.java
@@ -35,6 +35,10 @@ public class DiceRoller {
 
     public RollTestResult rollTest(Integer points, Integer bonus, Integer difficulty, Integer complexity, boolean allowCritical) {
 
+        if (complexity == null || complexity <= 0) {
+            complexity = 1;
+        }
+
         Integer numberOfRolls = Loh.getLevel(points);
         List<Roll> rolls = new ArrayList<>();
         Integer criticalSuccesses = 0;


### PR DESCRIPTION
## Summary
- handle invalid complexity in `DiceRoller.rollTest`

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684032e3cfe8832a9d714410b800ca89